### PR TITLE
pass through server options from config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var Config = require('./config')
 var downloads = require('./controllers/downloads')
 
 // Create the server
-var server = Hapi.createServer('0.0.0.0', Config.server.port);
+var server = Hapi.createServer('0.0.0.0', Config.server.port, Config.server.options);
 server.pack.require('./node_modules/hapi-mysql', Config.readDb, function(err) {
   if (err) {
     console.error(err);


### PR DESCRIPTION
in `config.js` (not in git) you can now add:

```
{
  "server": {
    "options": {
        "cors": true
    }
}
```

and it will enable CORS for the download counts website, which will make this work: http://requirebin.com/?gist=9554675
