### PR TITLE
Casting date strings to datetime before comparison using BETWEEN

### DIFF
--- a/controllers/downloads.js
+++ b/controllers/downloads.js
@@ -63,7 +63,7 @@ var parsePeriod = function(periodString) {
  */
 var getSumOfDays = function(request,reply,conditions,period) {
 
-  var sql = 'SELECT package, sum(downloads) as downloads FROM downloads WHERE day >= ? and day <= ?'
+  var sql = 'SELECT package, sum(downloads) as downloads FROM downloads WHERE day BETWEEN cast(? as datetime) and cast(? as datetime)'
   var bindValues = []
   var qmarks = []
   var bulk = false
@@ -150,10 +150,10 @@ var getRangeOfDays = function(request,reply,conditions,period) {
       bindValues.push(package)
     })
 
-    sql += 'SELECT package, day, downloads FROM downloads WHERE day >= ? and day <= ? AND package in (' + qmarks.join(',') + ') GROUP BY package,day'
+    sql += 'SELECT package, day, downloads FROM downloads WHERE day BETWEEN cast(? as datetime) and cast(? as datetime) AND package in (' + qmarks.join(',') + ') GROUP BY package,day'
   } else {
     // if all packages, group by day
-    sql += 'SELECT day, SUM(downloads) as downloads FROM downloads WHERE day >= ? and day <= ? GROUP BY day'
+    sql += 'SELECT day, SUM(downloads) as downloads FROM downloads WHERE day BETWEEN cast(? as datetime) and cast(? as datetime) GROUP BY day'
   }
   sql += ' ORDER BY day'
 

--- a/index.js
+++ b/index.js
@@ -42,4 +42,6 @@ server.route({
 });
 
 // Start the server
-server.start();
+server.start(function() {
+  console.log("Downloads API running on port " + server._port)
+});


### PR DESCRIPTION
According to http://dev.mysql.com/doc/refman/5.0/en/comparison-operators.html#operator_between using CAST and BETWEEN will be faster but so far EXPLAIN is showing no difference. Doesn't hurt, though.